### PR TITLE
Authentication simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ That means I'm writing it up all the way from bare TCP sockets. Just using `Glib
 ## Swift Package Manager
 
 ```swift
-.Package(url: "https://github.com/czechboy0/Redbird.git", majorVersion: 0, minor: 0)
+.Package(url: "https://github.com/czechboy0/Redbird.git", majorVersion: 0)
 ```
 
 ## CocoaPods

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Create a Redbird instance, which opens a socket to the specified Redis server. T
 ```swift
 do {
 	let client = try Redbird(address: "127.0.0.1", port: 6379)
+	try client.auth(password: "mypass1") // call .auth once after creation if your Redis requires a password
 	let response = try client.command("SET", params: ["mykey", "hello_redis"]).toString() //"OK"
 } catch {
 	print("Redis error: \(error)")
@@ -54,6 +55,7 @@ Instead of handling the `RespObject` types directly, you can also use the follow
 - `.toMaybeArray() -> [RespObject]?`
 - `.toInt() -> Int`
 - `.toBool() -> Bool`
+- `.toError() -> ErrorType`
 
 All of the above converters throw an error if invoked on a non-compatible type (like calling `toArray()` on an `Integer`).
 

--- a/Sources/Redbird/Errors.swift
+++ b/Sources/Redbird/Errors.swift
@@ -20,4 +20,5 @@ public enum RedbirdError: ErrorType {
     case NoFormatterFoundForObject(RespObject)
     case MoreThanOneWordSpecifiedAsCommand(String)
     case WrongNativeTypeUnboxing(RespObject, String)
+    case UnexpectedReturnedObject(RespObject)
 }

--- a/Sources/Redbird/ExternalTypeConversions.swift
+++ b/Sources/Redbird/ExternalTypeConversions.swift
@@ -57,4 +57,12 @@ extension RespObject {
         default: throw RedbirdError.WrongNativeTypeUnboxing(self, "Bool")
         }
     }
+    
+    public func toError() throws -> Error {
+        switch self.respType {
+        case .Error: return (self as! Error)
+        default: throw RedbirdError.WrongNativeTypeUnboxing(self, "Error")
+        }
+    }
+
 }

--- a/Sources/Redbird/RedbirdExtensions.swift
+++ b/Sources/Redbird/RedbirdExtensions.swift
@@ -8,3 +8,15 @@
 
 //TODO: https://github.com/czechboy0/Redbird/issues/4
 
+extension Redbird {
+    
+    public func auth(password password: String) throws {
+        let ret = try self.command("AUTH", params: [password])
+        switch ret.respType {
+        case .Error: throw try ret.toError()
+        case .SimpleString: if try ret.toString() == "OK" { return }
+        default: break
+        }
+        throw RedbirdError.UnexpectedReturnedObject(ret)
+    }
+}

--- a/Tests/ConversionTests.swift
+++ b/Tests/ConversionTests.swift
@@ -96,5 +96,13 @@ class ConversionTests: XCTestCase {
             XCTAssertEqual(ret, false)
         }
     }
+    
+    func testError_Ok() {
+        assertNoThrow {
+            let orig = Error(content: "NOAUTH Password required")
+            let ret = try orig.toError()
+            XCTAssertEqual(ret.content, "NOAUTH Password required")
+        }
+    }
 
 }


### PR DESCRIPTION
Added .auth convenience command on the client to pass the password to Redis instances requiring a password.

Fixed #2.